### PR TITLE
Hebrew as a supported language in LanguagePicker

### DIFF
--- a/components/LanguagePicker/LanguagePicker.js
+++ b/components/LanguagePicker/LanguagePicker.js
@@ -16,7 +16,8 @@ jQuery.fn.definePlugin('LanguagePicker', function () {
 		'Ru': 'Русский', 
 		'Ja': '日本語', 
 		'Ko': '한국어', 
-		'Tr': 'Türkçe'
+		'Tr': 'Türkçe',
+		'He': 'עברית'
 	};
 	
 	return {


### PR DESCRIPTION
Hebrew is now supported, but does not appear by default. You can explicitly add it to the `languages` option when you wish to include it.