### PR TITLE
Fix slider click producing NaN for Firefox.

### DIFF
--- a/components/Slider/Slider.js
+++ b/components/Slider/Slider.js
@@ -65,9 +65,9 @@ jQuery.fn.definePlugin('Slider', function ($) {
 			}
 		},
 		getXFromEvent: function(event){
-			var x = event.hasOwnProperty('offsetX') ?
-					event.offsetX :
-					event.clientX - event.target.getBoundingClientRect().left;
+			var x = event.offsetX !== undefined
+					? event.offsetX
+					: event.clientX - event.target.getBoundingClientRect().left;
 			return x / this.$el.width();
 		},
 		bindEvents: function () {

--- a/components/Slider/Slider.js
+++ b/components/Slider/Slider.js
@@ -65,7 +65,10 @@ jQuery.fn.definePlugin('Slider', function ($) {
 			}
 		},
 		getXFromEvent: function(event){
-			return event.offsetX / this.$el.width()
+			var x = event.hasOwnProperty('offsetX') ?
+					event.offsetX :
+					event.clientX - event.target.getBoundingClientRect().left;
+			return x / this.$el.width();
 		},
 		bindEvents: function () {
 			var $body = $(window);


### PR DESCRIPTION
Firefox (geko) has no event.offsetX, we have to calculate offset by
using target elements position and event.clientX.