### PR TITLE
Fix spinner input value not changing.

### DIFF
--- a/components/Spinner/Spinner.js
+++ b/components/Spinner/Spinner.js
@@ -109,9 +109,11 @@ jQuery.fn.definePlugin('Spinner', function ($) {
 		},
 		setValue: function (valueInRange) {
             this.options.value = this.valueInRangeToInnerRange(valueInRange);
+			if (valueInRange !== this.last_value) {
+				this.update();
+			}
 			if (this.options.value !== this.last_value) {
                 this.last_value = this.options.value;
-				this.update();
 				return true;
 			}
 		},

--- a/tests/SpinnerSpec.js
+++ b/tests/SpinnerSpec.js
@@ -150,6 +150,20 @@ describe('Spinner', function () {
 		expect($element.hasClass('default')).toBeTruthy();
 	});
 
+    it('should change input value two times in a row', function () {
+        Wix.UI.initializePlugin(element);
+        var $input = $element.find('input');
+        var event = givenEnterPressedEvent();
+        $input.val('1001');
+        $input.trigger(event);
+        expect(Wix.UI.get('numOfItems')).toBe(1000);
+        expect($input.val()).toBe('1000');
+        $input.val('1001');
+        $input.trigger(event);
+        expect(Wix.UI.get('numOfItems')).toBe(1000);
+        expect($input.val()).toBe('1000');
+    });
+
 	function givenSpinner(options){
 		options = options || {};
 		$element.attr('wix-options', JSON.stringify(options));


### PR DESCRIPTION
Spinner, when setting a value, checks if it's different from old
one. But the value that old one is compared against is already adjusted
to fit allowed range, thus not updating input value if two out of range
inputs are tried.

This commit fixes above problem by updating input value when actual
new input is different from old one. Other behaviour is preserved to
return 'true' only when adjusted values change.